### PR TITLE
Add iptables-restore shim for WireGuard

### DIFF
--- a/qbittorrent1/CHANGELOG.md
+++ b/qbittorrent1/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.2-16 (19-11-2025)
+- FIX: add an iptables-restore shim that retries without comment matches and falls back to legacy backends when the host kernel lacks the comment module.
+
 ## 5.1.2-15 (19-11-2025)
 - FIX: strip IPv6 configuration from the WireGuard runtime file to avoid host environments without IPv6 firewall or sysctl support.
 - FIX: add a sysctl shim to suppress `net.ipv4.conf.all.src_valid_mark` permission failures from wg-quick.

--- a/qbittorrent1/README.md
+++ b/qbittorrent1/README.md
@@ -180,6 +180,7 @@ Delete your nova3 folder in /config and restart qbittorrent
 - If your deployment expects inbound peers, verify that the UDP port exposed in the add-on options maps 51820/udp and is forwarded by your router. Skip this step for outbound-only commercial VPN providers.
 - Confirm that the selected configuration file in `/config/wireguard` matches the `wireguard_config` option (or that only one `.conf` file is present).
 - Check the add-on logs for the detailed `wg-quick` error message printed by the startup routine.
+- Hosts missing the iptables `comment` kernel module are automatically retried without comment matches and, when available, using the legacy iptables backend. Inspect the log for messages about these fallbacks if you see iptables-restore errors.
 - IPv6 settings are removed at startup; ensure your tunnel supports IPv4-only operation.
 - The startup scripts suppress the `net.ipv4.conf.all.src_valid_mark` sysctl failure emitted by `wg-quick` on some hosts, so persistent errors in the logs typically point to configuration or connectivity issues.
 

--- a/qbittorrent1/config.yaml
+++ b/qbittorrent1/config.yaml
@@ -146,4 +146,4 @@ schema:
 slug: qbittorrent1
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 5.1.2-15
+version: 5.1.2-16

--- a/qbittorrent1/rootfs/usr/local/sbin/iptables-restore
+++ b/qbittorrent1/rootfs/usr/local/sbin/iptables-restore
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REAL_IPTABLES_RESTORE="/sbin/iptables-restore"
+if [[ ! -x "${REAL_IPTABLES_RESTORE}" ]]; then
+    REAL_IPTABLES_RESTORE="/usr/sbin/iptables-restore"
+fi
+
+cleanup() {
+    [[ -n "${RULES_FILE:-}" && -f "${RULES_FILE}" ]] && rm -f "${RULES_FILE}"
+    [[ -n "${SANITIZED_FILE:-}" && -f "${SANITIZED_FILE}" ]] && rm -f "${SANITIZED_FILE}"
+}
+trap cleanup EXIT
+
+RULES_FILE="$(mktemp)"
+cat > "${RULES_FILE}"
+
+# First attempt with the original ruleset
+if output="$(${REAL_IPTABLES_RESTORE} "$@" < "${RULES_FILE}" 2>&1)"; then
+    [[ -n "${output}" ]] && printf '%s\n' "${output}" >&2
+    exit 0
+fi
+status=$?
+
+# Retry without comment matches if the kernel is missing the comment module
+SANITIZED_FILE="$(mktemp)"
+sed -E 's/-m[[:space:]]+comment[[:space:]]+--comment[[:space:]]+"[^"]*"//g' "${RULES_FILE}" > "${SANITIZED_FILE}"
+
+if retry_output="$(${REAL_IPTABLES_RESTORE} "$@" < "${SANITIZED_FILE}" 2>&1)"; then
+    printf '%s\n' "iptables-restore failed with comment matches; reapplied without comments." >&2
+    printf '%s\n' "Original error: ${output}" >&2
+    [[ -n "${retry_output}" ]] && printf '%s\n' "${retry_output}" >&2
+    exit 0
+fi
+retry_status=$?
+
+# Final fallback: try legacy backend if available
+for legacy in /sbin/iptables-restore-legacy /usr/sbin/iptables-restore-legacy; do
+    if [[ -x "${legacy}" ]]; then
+        if legacy_output="$(${legacy} "$@" < "${RULES_FILE}" 2>&1)"; then
+            printf '%s\n' "iptables-restore failed; succeeded using legacy backend." >&2
+            printf '%s\n' "Original error: ${output}" >&2
+            [[ -n "${legacy_output}" ]] && printf '%s\n' "${legacy_output}" >&2
+            exit 0
+        fi
+    fi
+done
+
+printf '%s\n' "iptables-restore failed and fallbacks were unsuccessful." >&2
+printf '%s\n' "Original error: ${output}" >&2
+printf '%s\n' "Sanitized retry error: ${retry_output}" >&2
+exit ${retry_status}


### PR DESCRIPTION
## Summary
- add an iptables-restore wrapper to retry without comment matches and fall back to legacy backends
- document WireGuard fallback behavior in the README
- record the change in the changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4e29a3ec83259fb83eb40afb2b8a)