### PR TITLE
Fix WireGuard runtime config naming

### DIFF
--- a/qbittorrent1/config.yaml
+++ b/qbittorrent1/config.yaml
@@ -146,4 +146,4 @@ schema:
 slug: qbittorrent1
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 5.1.2-16
+version: 5.1.2-17

--- a/qbittorrent1/rootfs/etc/cont-init.d/94-wireguard.sh
+++ b/qbittorrent1/rootfs/etc/cont-init.d/94-wireguard.sh
@@ -122,7 +122,7 @@ if [[ -z "${interface_name}" ]]; then
     interface_name='wg0'
 fi
 
-wireguard_runtime_config="${WIREGUARD_STATE_DIR}/${interface_name}.ipv4.conf"
+wireguard_runtime_config="${WIREGUARD_STATE_DIR}/${interface_name}.conf"
 
 sanitize_wireguard_config_ipv4_only "${wireguard_config}" "${wireguard_runtime_config}"
 chmod 600 "${wireguard_runtime_config}" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- ensure the generated WireGuard runtime config keeps the interface name by using a `.conf` filename

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5ed973e08325ac9f57ff7c85682a)