### PR TITLE
Add connection_upgrade map for nginx ingress

### DIFF
--- a/netalertx/rootfs/etc/nginx/http.d/ingress.conf
+++ b/netalertx/rootfs/etc/nginx/http.d/ingress.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen %%interface%%:%%port%% default_server;
     server_name netalertx;


### PR DESCRIPTION
## Summary
- define a map for the connection_upgrade variable to prevent nginx startup errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694714ab2e38832592eaa4cfc53cd0da)