### PR TITLE
Handle missing Karakeep migration script

### DIFF
--- a/karakeep_wg/config.yaml
+++ b/karakeep_wg/config.yaml
@@ -1,5 +1,5 @@
 name: Karakeep WireGuard
-version: "0.1.0"
+version: "0.1.1"
 slug: karakeep_wg
 description: Run Karakeep with a persistent Chromium profile routed through WireGuard.
 url: https://github.com/alexbelgium/hassio-addons

--- a/karakeep_wg/rootfs/etc/cont-init.d/30-db-migrate.sh
+++ b/karakeep_wg/rootfs/etc/cont-init.d/30-db-migrate.sh
@@ -7,10 +7,18 @@ source /usr/lib/bashio/bashio.sh
 PUID=$(bashio::config 'PUID')
 PGID=$(bashio::config 'PGID')
 
-if [[ ! -f /db_migrations/index.js ]]; then
-  bashio::log.error "Karakeep migration script not found"
-  bashio::exit.nok
+migration_script=""
+
+if [[ -f /db_migrations/index.js ]]; then
+  migration_script="/db_migrations/index.js"
+elif [[ -f /app/db_migrations/index.js ]]; then
+  migration_script="/app/db_migrations/index.js"
+fi
+
+if [[ -z "${migration_script}" ]]; then
+  bashio::log.warning "Karakeep migration script not found; skipping migrations"
+  exit 0
 fi
 
 bashio::log.info "Running Karakeep database migrations"
-exec s6-setuidgid "${PUID}:${PGID}" node /db_migrations/index.js
+exec s6-setuidgid "${PUID}:${PGID}" node "${migration_script}"

--- a/karakeep_wg/rootfs/etc/cont-init.d/30-db-migrate.sh
+++ b/karakeep_wg/rootfs/etc/cont-init.d/30-db-migrate.sh
@@ -8,15 +8,21 @@ PUID=$(bashio::config 'PUID')
 PGID=$(bashio::config 'PGID')
 
 migration_script=""
+candidate_paths=(
+  /db_migrations/index.js
+  /app/db_migrations/index.js
+)
 
-if [[ -f /db_migrations/index.js ]]; then
-  migration_script="/db_migrations/index.js"
-elif [[ -f /app/db_migrations/index.js ]]; then
-  migration_script="/app/db_migrations/index.js"
-fi
+for candidate in "${candidate_paths[@]}"; do
+  if [[ -f "${candidate}" ]]; then
+    migration_script="${candidate}"
+    break
+  fi
+done
 
 if [[ -z "${migration_script}" ]]; then
-  bashio::log.warning "Karakeep migration script not found; skipping migrations"
+  bashio::log.warning \
+    "Karakeep migration script not found in /db_migrations or /app/db_migrations; skipping migrations"
   exit 0
 fi
 


### PR DESCRIPTION
### Motivation
- Prevent the container from failing to start when the Karakeep database migration script is not present.
- Support images/layouts where migrations may be located at either `/db_migrations/index.js` or `/app/db_migrations/index.js`.

### Description
- Add a `migration_script` variable and check for the script in `/db_migrations/index.js` and `/app/db_migrations/index.js`.
- If no migration script is found, log a warning via `bashio::log.warning` and exit with success to skip migrations.
- Run migrations with `exec s6-setuidgid "${PUID}:${PGID}" node "${migration_script}"` when a script is found.
- Updated file: `karakeep_wg/rootfs/etc/cont-init.d/30-db-migrate.sh`.

### Testing
- No automated tests were run for this change.
- The change was committed locally as part of the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964163f842083259ef08793ea22fe04)