### PR TITLE
Migrate bashio::addon to bashio::app

### DIFF
--- a/.templates/bashio-standalone.sh
+++ b/.templates/bashio-standalone.sh
@@ -170,12 +170,12 @@ bashio::supervisor.ping() {
 # -----------------------------------------------------------------------------
 # Add-on metadata
 # -----------------------------------------------------------------------------
-bashio::addon.name()         { printf '%s' "${ADDON_NAME:-Standalone container}"; }
-bashio::addon.description()  { printf '%s' "${ADDON_DESCRIPTION:-Running without Home Assistant Supervisor}"; }
-bashio::addon.version()      { printf '%s' "${BUILD_VERSION:-1.0}"; }
-bashio::addon.version_latest(){ printf '%s' "${ADDON_VERSION_LATEST:-${BUILD_VERSION:-1.0}}"; }
+bashio::app.name()         { printf '%s' "${ADDON_NAME:-Standalone container}"; }
+bashio::app.description()  { printf '%s' "${ADDON_DESCRIPTION:-Running without Home Assistant Supervisor}"; }
+bashio::app.version()      { printf '%s' "${BUILD_VERSION:-1.0}"; }
+bashio::app.version_latest(){ printf '%s' "${ADDON_VERSION_LATEST:-${BUILD_VERSION:-1.0}}"; }
 
-bashio::addon.update_available() {
+bashio::app.update_available() {
   if [ -n "${ADDON_VERSION_LATEST:-}" ] && [ "${ADDON_VERSION_LATEST:-}" != "${BUILD_VERSION:-}" ]; then
     printf '%s' "true"
   else
@@ -183,14 +183,14 @@ bashio::addon.update_available() {
   fi
 }
 
-bashio::addon.ingress_port()  { printf '%s' "${ADDON_INGRESS_PORT:-}"; }
-bashio::addon.ingress_entry() { printf '%s' "${ADDON_INGRESS_ENTRY:-}"; }
-bashio::addon.ip_address()    { printf '%s' "${ADDON_IP_ADDRESS:-}"; }
+bashio::app.ingress_port()  { printf '%s' "${ADDON_INGRESS_PORT:-}"; }
+bashio::app.ingress_entry() { printf '%s' "${ADDON_INGRESS_ENTRY:-}"; }
+bashio::app.ip_address()    { printf '%s' "${ADDON_IP_ADDRESS:-}"; }
 
 # Ports:
 # - numeric arg "8080" -> env PORT_8080 or ADDON_PORT_8080, fallback to the number
 # - non-numeric "WEB_PORT" -> resolve as config/env key
-bashio::addon.port() {
+bashio::app.port() {
   local arg="${1:-}"
   if [[ "$arg" =~ ^[0-9]+$ ]]; then
     local v=""
@@ -202,8 +202,8 @@ bashio::addon.port() {
   fi
 }
 
-# addon.option : write/delete option in JSON when possible; fallback export env
-bashio::addon.option() {
+# app.option : write/delete option in JSON when possible; fallback export env
+bashio::app.option() {
   local key="${1:-}" value="${2-__BASHIO_UNSET__}" file="${STANDALONE_OPTIONS_JSON:-}"
   [ -n "$key" ] || return 0
 

--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -68,7 +68,7 @@ SHEBANG_ERRORS=()
 probe_script_content='
 set -e
 
-if ! command -v bashio::addon.version >/dev/null 2>&1; then
+if ! command -v bashio::app.version >/dev/null 2>&1; then
   for f in \
     /usr/lib/bashio/bashio.sh \
     /usr/lib/bashio/lib.sh \
@@ -85,7 +85,7 @@ fi
 
 # Try regular bashio, fallback to standalone if unavailable or fails
 set +e
-_bv="$(bashio::addon.version 2>/dev/null)"
+_bv="$(bashio::app.version 2>/dev/null)"
 _rc=$?
 set -e
 
@@ -94,7 +94,7 @@ if [ "$_rc" -ne 0 ] || [ -z "$_bv" ] || [ "$_bv" = "null" ]; then
     if [ -f "$_sf" ]; then
       # shellcheck disable=SC1090
       . "$_sf"
-      _bv="$(bashio::addon.version 2>/dev/null || true)"
+      _bv="$(bashio::app.version 2>/dev/null || true)"
       break
     fi
   done
@@ -158,7 +158,7 @@ for candidate in "${candidate_shebangs[@]}"; do
 done
 
 if [ -z "$shebang" ]; then
-  echo "ERROR: No valid shebang found (unable to execute bashio::addon.version via candidates)." >&2
+  echo "ERROR: No valid shebang found (unable to execute bashio::app.version via candidates)." >&2
   echo "Tried:" >&2
   printf ' - %s\n' "${candidate_shebangs[@]}" >&2
   if [ "${#SHEBANG_ERRORS[@]}" -gt 0 ]; then


### PR DESCRIPTION
Replace all deprecated bashio::addon.* calls with bashio::app.* across
ha_entrypoint.sh and bashio-standalone.sh, following the bashio deprecation notice.

https://claude.ai/code/session_01K8BHcdHgLg2xJMxfX9Nmuf